### PR TITLE
create a constructor when this is no constructor

### DIFF
--- a/execution/evm/abi/spec.go
+++ b/execution/evm/abi/spec.go
@@ -145,7 +145,7 @@ func (spec *Spec) Pack(fname string, args ...interface{}) ([]byte, *FunctionSpec
 		if spec.Constructor.Inputs != nil {
 			funcSpec = spec.Constructor
 		} else {
-			return nil, nil, fmt.Errorf("contract does not have a constructor")
+			funcSpec = &FunctionSpec{}
 		}
 	}
 


### PR DESCRIPTION
修复无constructor时报错问题。
修复方法为：无构造函数时，创建一个空的构造函数。