### PR TITLE
修复16进制string被直接转成[]byte的问题

### DIFF
--- a/execution/evm/abi/primitives.go
+++ b/execution/evm/abi/primitives.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -588,10 +589,18 @@ func (e EVMBytes) getGoType() interface{} {
 
 func (e EVMBytes) pack(v interface{}) ([]byte, error) {
 	b, ok := v.([]byte)
+	var err error
 	if !ok {
 		s, ok := v.(string)
 		if ok {
-			b = []byte(s)
+			if len(s) > 2 && s[:2] == "0x" {
+				b, err = hex.DecodeString(s[2:])
+				if err != nil {
+					return nil, fmt.Errorf("cannot map from %s to EVM bytes", s)
+				}
+			} else {
+				b = []byte(s)
+			}
 		} else {
 			return nil, fmt.Errorf("cannot map from %s to EVM bytes", reflect.ValueOf(v).Kind().String())
 		}


### PR DESCRIPTION
合约参数定义为一个bytes4类型，实际入参为一个0x开头的16进制字符串时，程序会按照字符串个数直接转成[]byte,从而造成错误。